### PR TITLE
Add the Builder pattern using file format converters as an example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.0
+Add the Builder pattern using file format converters as an example
+
 ## 0.1.0
 - Add pattern Prototype  
   

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ Here's a style guide which might help you to keep your changes consistent with o
 
 4. File names should match following convention: `some_class_name.dart`
 
-5. Places classes into separate files.
-
-6. Comments may or may not have language tags in them, such as this:
+5. Comments may or may not have language tags in them, such as this:
 
     ```dart
     /**

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It contains **Dart** examples for all classic GoF design patterns.
 # Implementation checklist:
 - [ ] **Creation**
     - [ ] Abstract Factory
-    - [ ] Builder
+    - [x] Builder
     - [ ] Factory Method
     - [x] Prototype
     - [ ] Singleton

--- a/bin/builder/file_format/color_reader/color_text_reader.dart
+++ b/bin/builder/file_format/color_reader/color_text_reader.dart
@@ -4,7 +4,7 @@ class ColorTextReader {
 
   ColorTextReader({required this.text});
 
-  TextFormat convert(Converter converter) {
+  T convert<T extends TextFormat>(Converter<T> converter) {
     for (final word in text.split(' ')) {
       if (supportedColors.contains(word)) {
         converter.writeColor(word);

--- a/bin/builder/file_format/color_text_reader.dart
+++ b/bin/builder/file_format/color_text_reader.dart
@@ -33,6 +33,6 @@ abstract class TextFormat {
 
   @override
   String toString() => '$runtimeType(\n'
-      '  $content'
+      '$content'
       '\n)';
 }

--- a/bin/builder/file_format/color_text_reader.dart
+++ b/bin/builder/file_format/color_text_reader.dart
@@ -1,0 +1,38 @@
+/// Director
+class ColorTextReader {
+  final String text;
+
+  ColorTextReader({required this.text});
+
+  TextFormat convert(Converter converter) {
+    for (final word in text.split(' ')) {
+      if (supportedColors.contains(word)) {
+        converter.writeColor(word);
+      } else {
+        converter.writeWord(word);
+      }
+    }
+    return converter.result;
+  }
+
+  final supportedColors = Set.unmodifiable(['red', 'green', 'blue']);
+}
+
+/// Builder
+abstract class Converter<T extends TextFormat> {
+  void writeWord(String text);
+
+  void writeColor(String color);
+
+  T get result;
+}
+
+/// Product
+abstract class TextFormat {
+  String get content;
+
+  @override
+  String toString() => '$runtimeType(\n'
+      '  $content'
+      '\n)';
+}

--- a/bin/builder/file_format/converters/console_converter.dart
+++ b/bin/builder/file_format/converters/console_converter.dart
@@ -1,0 +1,17 @@
+import '../formats/console_format.dart';
+import '../color_text_reader.dart';
+
+class ConsoleConverter extends Converter<ConsoleFormat> {
+  @override
+  final result = ConsoleFormat();
+
+  @override
+  void writeColor(String color) {
+    result.color = color;
+    result.write(color);
+    result.color = 'black';
+  }
+
+  @override
+  void writeWord(String text) => result.write(text);
+}

--- a/bin/builder/file_format/converters/console_converter.dart
+++ b/bin/builder/file_format/converters/console_converter.dart
@@ -1,5 +1,5 @@
 import '../formats/console_format.dart';
-import '../color_text_reader.dart';
+import '../color_reader/color_text_reader.dart';
 
 class ConsoleConverter extends Converter<ConsoleFormat> {
   @override

--- a/bin/builder/file_format/converters/html_converter.dart
+++ b/bin/builder/file_format/converters/html_converter.dart
@@ -1,0 +1,24 @@
+import '../formats/html_format.dart';
+import '../color_text_reader.dart';
+
+/// Builder
+class HtmlConverter extends Converter<HtmlFormat> {
+  @override
+  HtmlFormat get result => _html..closeAllTags();
+
+  @override
+  void writeColor(String color) {
+    _html
+        .addStyle(name: color, color: color)
+        .openTagSpan(styleName: color)
+        .writeText(color)
+        .closeLastTag();
+  }
+
+  @override
+  void writeWord(String text) {
+    _html.writeText('$text ');
+  }
+
+  final _html = HtmlFormat()..openTagP();
+}

--- a/bin/builder/file_format/converters/html_converter.dart
+++ b/bin/builder/file_format/converters/html_converter.dart
@@ -1,5 +1,5 @@
 import '../formats/html_format.dart';
-import '../color_text_reader.dart';
+import '../color_reader/color_text_reader.dart';
 
 /// Builder
 class HtmlConverter extends Converter<HtmlFormat> {

--- a/bin/builder/file_format/converters/json_converter.dart
+++ b/bin/builder/file_format/converters/json_converter.dart
@@ -3,15 +3,26 @@ import '../color_text_reader.dart';
 
 class JsonConverter extends Converter<JsonFormat> {
   @override
-  final result = JsonFormat();
+  JsonFormat get result => _json;
+
+  final _json = JsonFormat();
 
   @override
   void writeColor(String color) {
-    throw UnimplementedError();
+    if (_textBuffer.isNotEmpty) {
+      _json.add({
+        'text': _textBuffer.toString(),
+      });
+      _textBuffer.clear();
+    }
+    _json.add({
+      'text': color,
+      'color': color,
+    });
   }
 
+  final _textBuffer = StringBuffer();
+
   @override
-  void writeWord(String text) {
-    throw UnimplementedError();
-  }
+  void writeWord(String text) => _textBuffer.write('$text ');
 }

--- a/bin/builder/file_format/converters/json_converter.dart
+++ b/bin/builder/file_format/converters/json_converter.dart
@@ -1,0 +1,17 @@
+import '../formats/json_format.dart';
+import '../color_text_reader.dart';
+
+class JsonConverter extends Converter<JsonFormat> {
+  @override
+  final result = JsonFormat();
+
+  @override
+  void writeColor(String color) {
+    throw UnimplementedError();
+  }
+
+  @override
+  void writeWord(String text) {
+    throw UnimplementedError();
+  }
+}

--- a/bin/builder/file_format/converters/json_converter.dart
+++ b/bin/builder/file_format/converters/json_converter.dart
@@ -1,5 +1,5 @@
 import '../formats/json_format.dart';
-import '../color_text_reader.dart';
+import '../color_reader/color_text_reader.dart';
 
 class JsonConverter extends Converter<JsonFormat> {
   @override

--- a/bin/builder/file_format/formats/console_format.dart
+++ b/bin/builder/file_format/formats/console_format.dart
@@ -1,7 +1,7 @@
 import '../color_text_reader.dart';
 
 class ConsoleFormat extends TextFormat {
-  final _buff = <String>[];
+  final _buff = <String>[' '];
 
   static const colors = {
     'red': '\x1b[31m',

--- a/bin/builder/file_format/formats/console_format.dart
+++ b/bin/builder/file_format/formats/console_format.dart
@@ -1,0 +1,24 @@
+import '../color_text_reader.dart';
+
+class ConsoleFormat extends TextFormat {
+  final _buff = <String>[];
+
+  static const colors = {
+    'red': '\x1b[31m',
+    'green': '\x1b[32m',
+    'blue': '\x1b[34m',
+  };
+
+  var _fgColor = '';
+  var _end = '';
+
+  set color(String colorName) {
+    _fgColor = colors[colorName] ?? '';
+    _end = _fgColor == '' ? '' : '\x1B[0m';
+  }
+
+  void write(String text) => _buff.add('$_fgColor$text$_end');
+
+  @override
+  String get content => _buff.join(' ');
+}

--- a/bin/builder/file_format/formats/console_format.dart
+++ b/bin/builder/file_format/formats/console_format.dart
@@ -1,4 +1,4 @@
-import '../color_text_reader.dart';
+import '../color_reader/color_text_reader.dart';
 
 class ConsoleFormat extends TextFormat {
   final _buff = <String>[' '];

--- a/bin/builder/file_format/formats/html_format.dart
+++ b/bin/builder/file_format/formats/html_format.dart
@@ -1,0 +1,84 @@
+import 'dart:collection';
+
+import '../color_text_reader.dart';
+
+// product
+class HtmlFormat extends TextFormat {
+  final _openTag = Queue<Tag>();
+  final _content = StringBuffer();
+
+  HtmlFormat openTagP() {
+    final tag = Tag('p');
+    _openTag.add(tag);
+    _content.write('  $tag\n   ');
+    return this;
+  }
+
+  final _styles = <String, String>{};
+
+  HtmlFormat addStyle({required String name, required String color}) {
+    _styles[name] = color;
+    return this;
+  }
+
+  HtmlFormat openTagSpan({String? styleName}) {
+    final tag = Tag('span', styleName);
+    _openTag.add(tag);
+    _content.write('\n   $tag');
+    return this;
+  }
+
+  HtmlFormat writeText(String text) {
+    _content.write(text);
+    return this;
+  }
+
+  HtmlFormat closeLastTag() {
+    final tagName = _openTag.removeLast().name;
+    _content.write('</$tagName> ');
+    return this;
+  }
+
+  HtmlFormat closeAllTags() {
+    while (_openTag.isNotEmpty) {
+      closeLastTag();
+    }
+    return this;
+  }
+
+  @override
+  String get content {
+    final styleContent = _styles.entries
+        .map((e) => '.${e.key} { color: ${e.value}; }')
+        .join('\n      ');
+
+    return '''<!DOCTYPE html>
+  <html>
+  <head>
+  <title>Color text</title>
+    <style>
+      $styleContent
+    </style>
+  </head>
+  <body>
+$_content
+  </body>
+</html>''';
+  }
+}
+
+class Tag {
+  final String name;
+  final String? className;
+  final text = StringBuffer();
+
+  Tag(this.name, [this.className]);
+
+  @override
+  String toString() {
+    final cls = className != null ? ' class="$className"' : '';
+    return '<$name$cls>$text';
+  }
+}
+
+mixin MixinTag {}

--- a/bin/builder/file_format/formats/html_format.dart
+++ b/bin/builder/file_format/formats/html_format.dart
@@ -1,6 +1,6 @@
 import 'dart:collection';
 
-import '../color_text_reader.dart';
+import '../color_reader/color_text_reader.dart';
 
 // product
 class HtmlFormat extends TextFormat {

--- a/bin/builder/file_format/formats/json_format.dart
+++ b/bin/builder/file_format/formats/json_format.dart
@@ -1,0 +1,16 @@
+import 'dart:convert';
+
+import '../color_text_reader.dart';
+
+class JsonFormat extends TextFormat {
+  @override
+  String get content => jsonEncode([
+        {
+          'text': 'some text',
+        },
+        {
+          'text': 'some text',
+          'color': 'red',
+        }
+      ],);
+}

--- a/bin/builder/file_format/formats/json_format.dart
+++ b/bin/builder/file_format/formats/json_format.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import '../color_text_reader.dart';
+import '../color_reader/color_text_reader.dart';
 
 class JsonFormat extends TextFormat {
   final _list = <Map<String, String>>[];

--- a/bin/builder/file_format/formats/json_format.dart
+++ b/bin/builder/file_format/formats/json_format.dart
@@ -3,14 +3,12 @@ import 'dart:convert';
 import '../color_text_reader.dart';
 
 class JsonFormat extends TextFormat {
+  final _list = <Map<String, String>>[];
+
+  void add(Map<String, String> item) {
+    _list.add(item);
+  }
+
   @override
-  String get content => jsonEncode([
-        {
-          'text': 'some text',
-        },
-        {
-          'text': 'some text',
-          'color': 'red',
-        }
-      ],);
+  String get content => JsonEncoder.withIndent('  ').convert(_list);
 }

--- a/bin/builder/file_format/main.dart
+++ b/bin/builder/file_format/main.dart
@@ -1,7 +1,7 @@
 import 'converters/html_converter.dart';
 import 'converters/json_converter.dart';
-import 'color_text_reader.dart';
 import 'converters/console_converter.dart';
+import 'color_reader/color_text_reader.dart';
 
 void main() {
   final reader = ColorTextReader(

--- a/bin/builder/file_format/main.dart
+++ b/bin/builder/file_format/main.dart
@@ -1,0 +1,20 @@
+import 'converters/html_converter.dart';
+import 'converters/json_converter.dart';
+import 'color_text_reader.dart';
+import 'converters/console_converter.dart';
+
+void main() {
+  final reader = ColorTextReader(
+    text: 'I love looking at the blue sky, '
+        'eating red apples, '
+        'sitting on the green grass.',
+  );
+  final html = reader.convert(HtmlConverter());
+  final json = reader.convert(JsonConverter());
+  final console = reader.convert(ConsoleConverter());
+  print(
+    '$html,\n\n'
+    '$json,\n\n'
+    '$console,\n\n',
+  );
+}

--- a/bin/builder/file_format/output.txt
+++ b/bin/builder/file_format/output.txt
@@ -1,0 +1,50 @@
+HtmlFormat(
+<!DOCTYPE html>
+  <html>
+  <head>
+  <title>Color text</title>
+    <style>
+      .blue { color: blue; }
+      .red { color: red; }
+      .green { color: green; }
+    </style>
+  </head>
+  <body>
+  <p>
+   I love looking at the
+   <span class="blue">blue</span> sky, eating
+   <span class="red">red</span> apples, sitting on the
+   <span class="green">green</span> grass. </p>
+  </body>
+</html>
+),
+
+JsonFormat(
+[
+  {
+    "text": "I love looking at the "
+  },
+  {
+    "text": "blue",
+    "color": "blue"
+  },
+  {
+    "text": "sky, eating "
+  },
+  {
+    "text": "red",
+    "color": "red"
+  },
+  {
+    "text": "apples, sitting on the "
+  },
+  {
+    "text": "green",
+    "color": "green"
+  }
+]
+),
+
+ConsoleFormat(
+  I love looking at the blue sky, eating red apples, sitting on the green grass.
+),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: design_patterns_dart
 description: Dart examples for all classic GoF design patterns.
-version: 0.1.0
+version: 0.2.0
 homepage: https://refactoring.guru/design-patterns
 repository: https://github.com/RefactoringGuru/design-patterns-dart
 issue_tracker: https://github.com/RefactoringGuru/design-patterns-dart/issue


### PR DESCRIPTION
**Usecase:**
```dart
void main() {
  final reader = ColorTextReader(
    text: 'I love looking at the blue sky, '
        'eating red apples, '
        'sitting on the green grass.',
  );
  final html = reader.convert(HtmlConverter());
  final json = reader.convert(JsonConverter());
  final console = reader.convert(ConsoleConverter());
  print(
    '$html,\n\n'
    '$json,\n\n'
    '$console,\n\n',
  );
}
```

<details><summary>output:</summary>
<p>

```HtmlFormat(
<!DOCTYPE html>
  <html>
  <head>
  <title>Color text</title>
    <style>
      .blue { color: blue; }
      .red { color: red; }
      .green { color: green; }
    </style>
  </head>
  <body>
  <p>
   I love looking at the
   <span class="blue">blue</span> sky, eating
   <span class="red">red</span> apples, sitting on the
   <span class="green">green</span> grass. </p>
  </body>
</html>
),

JsonFormat(
[
  {
    "text": "I love looking at the "
  },
  {
    "text": "blue",
    "color": "blue"
  },
  {
    "text": "sky, eating "
  },
  {
    "text": "red",
    "color": "red"
  },
  {
    "text": "apples, sitting on the "
  },
  {
    "text": "green",
    "color": "green"
  }
]
),

ConsoleFormat(
  I love looking at the blue sky, eating red apples, sitting on the green grass.
),
```
</p>
</details>

**Checklist:**
- [x] Impl HtmlConverter
- [x] Impl ConsoleConverter
- [x] Impl JsonConverter
- [x] Wait for the approval of the pull request https://github.com/RefactoringGuru/design-patterns-dart/pull/2
- [x] Merge branch master with [builder-pattern-file-format-example](https://github.com/ilopX/design-patterns-dart/tree/builder-pattern-file-format-example)