### PR TITLE
Add "Tool Panel Factory" - flutter example.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.23.0
+- Add "Tool Panel Factory" flutter example
+
 ## 0.22.0
 - Add visitor pattern: "Shape Xml Export".
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It contains **Dart** examples for all classic **GoF** design patterns.
 
 # Implementation checklist:
 - [ ] **Creation**
-    - [x] **Abstract Factory** [[Conceptual Gui Factory](https://github.com/RefactoringGuru/design-patterns-dart/tree/main/patterns/abstract_factory/conceptual_gui_factory)]
+    - [x] **Abstract Factory** [[Conceptual Gui Factory](https://github.com/RefactoringGuru/design-patterns-dart/tree/main/patterns/abstract_factory/conceptual_gui_factory)] [[Tool Panel Factory](https://github.com/RefactoringGuru/design-patterns-dart/tree/main/patterns/abstract_factory/tool_panel_factory)]
     - [x] **Builder** - [[Color Text Format](https://github.com/RefactoringGuru/design-patterns-dart/tree/main/patterns/builder/color_text_format)]
     - [x] **Factory Method** [[Conceptual Platform Dialog](https://github.com/RefactoringGuru/design-patterns-dart/tree/main/patterns/factory_method/conceptual_platform_dialog)]
     - [x] **Prototype** - [[Shapes](https://github.com/RefactoringGuru/design-patterns-dart/tree/main/patterns/prototype/shapes)] 

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -19,7 +19,7 @@ class MyApp extends StatelessWidget {
         '/observer/subscriber_flutter_widget': (_) => SubscriberFlutterApp(),
         '/adapter/flutter_adapter': (_) => FlutterAdapterApp(),
         '/memento/flutter_memento_editor': (_) => FlutterMementoEditorApp(),
-        '/abstract_factory/tool_panel': (_) => WToolPanelApp(),
+        '/abstract_factory/tool_panel_factory': (_) => ToolPanelFactoryApp(),
       },
     );
   }

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../patterns/abstract_factory/tool_panel_factory/main.dart';
 import '../patterns/observer/subscriber_flutter_widget/main.dart';
 import '../patterns/adapter/flutter_adapter/main.dart';
 import '../patterns/memento/memento_editor/main.dart';
@@ -13,11 +14,12 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Refactoring Guru: Flutter launcher',
       theme: ThemeData(primarySwatch: Colors.pink),
-      initialRoute: '/memento/flutter_memento_editor',
+      initialRoute: '/abstract_factory/tool_panel',
       routes: {
         '/observer/subscriber_flutter_widget': (_) => SubscriberFlutterApp(),
         '/adapter/flutter_adapter': (_) => FlutterAdapterApp(),
         '/memento/flutter_memento_editor': (_) => FlutterMementoEditorApp(),
+        '/abstract_factory/tool_panel': (_) => WToolPanelApp(),
       },
     );
   }

--- a/patterns/abstract_factory/tool_panel_factory/README.md
+++ b/patterns/abstract_factory/tool_panel_factory/README.md
@@ -1,0 +1,49 @@
+# Abstract Factory Pattern
+Abstract Factory is a creational design pattern that lets you produce families of related objects 
+without specifying their concrete classes.
+
+Tutorial: [here](https://refactoring.guru/design-patterns/abstract-factory).
+
+### Online demo:
+Click on the picture to see the [demo](https://RefactoringGuru.github.io/design-patterns-dart/#/abstract_factory/tool_panel_factory).
+
+[![image](https://user-images.githubusercontent.com/8049534/168668992-369a1bab-9f97-4333-a20e-ffd06bf91b54.png)](https://refactoringguru.github.io/design-patterns-dart/#/abstract_factory/tool_panel_factory)
+
+### Diagram:
+![image](https://user-images.githubusercontent.com/8049534/168672053-73ae1c9c-8fad-45ae-9247-429f7b5da565.png)
+
+### Client code (using the "createShape" method):
+```dart
+final app = App(
+  tools: Tools(
+    factories: [
+      TxtFactory(),
+      LineFactory(),
+      CircleFactory(),
+      TriangleFactory(),
+      StarFactory(),
+    ],
+  ),
+);
+
+class App {
+  void addShape(double x, double y) {
+    final newShape = activeFactory.createShape(x, y, activeColor);
+    shapes.add(newShape);
+  }
+}
+
+mixin IconBoxMixin implements FactoryTool {
+  Image? _icon;
+
+  @override
+  Image get icon => _icon!;
+
+  Future<void> updateIcon(Color color) async {
+    final shape = createShape(0, 0, color);
+    final pngBytes = await _pngImageFromShape(shape);
+    _icon = Image.memory(pngBytes);
+  }
+}
+```
+

--- a/patterns/abstract_factory/tool_panel_factory/app/app.dart
+++ b/patterns/abstract_factory/tool_panel_factory/app/app.dart
@@ -1,0 +1,21 @@
+import '../app/tools.dart';
+import 'shapes.dart';
+
+class App {
+  final Tools tools;
+  final Shapes shapes;
+
+  App({
+    required this.tools,
+    required this.shapes,
+  });
+
+  void addShape(double x, double y) {
+    final activeColor = tools.activeColor.value;
+    final activeFactory = tools.activeFactory.value!;
+
+    final newShape = activeFactory.createShape(x, y, activeColor);
+    newShape.centerToFit();
+    shapes.add(newShape);
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/app/shapes.dart
+++ b/patterns/abstract_factory/tool_panel_factory/app/shapes.dart
@@ -1,0 +1,25 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+import '../pattern/shape.dart';
+
+class Shapes with IterableMixin<Shape> {
+  final List<Shape> _shapes;
+
+  Shapes(this._shapes);
+
+  void add(Shape shape) {
+    _shapes.add(shape);
+    onAddShapeEvent._emit();
+  }
+
+  @override
+  Iterator<Shape> get iterator => _shapes.iterator;
+
+  final onAddShapeEvent = Event();
+}
+
+class Event extends ChangeNotifier {
+  void _emit() => notifyListeners();
+}

--- a/patterns/abstract_factory/tool_panel_factory/app/tools.dart
+++ b/patterns/abstract_factory/tool_panel_factory/app/tools.dart
@@ -7,10 +7,10 @@ import '../mixin/icon_box_mixin.dart';
 import '../pattern/tool_factory.dart';
 
 class Tools {
-  final List<FactoryTool> factories;
+  final List<ToolFactory> factories;
   final List<Color> colors;
 
-  final activeFactory = ValueNotifier<FactoryTool?>(null);
+  final activeFactory = ValueNotifier<ToolFactory?>(null);
 
   final activeColor = ValueNotifier(Color(0x0FFFFFFFF));
 

--- a/patterns/abstract_factory/tool_panel_factory/app/tools.dart
+++ b/patterns/abstract_factory/tool_panel_factory/app/tools.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+
+import '../mixin/icon_box_mixin.dart';
+import '../pattern/tool_factory.dart';
+
+class Tools {
+  final List<FactoryTool> factories;
+  final List<Color> colors;
+
+  final activeFactory = ValueNotifier<FactoryTool?>(null);
+
+  final activeColor = ValueNotifier(Color(0x0FFFFFFFF));
+
+  Future<bool> get iconsReady => _iconsInitCompleter.future;
+
+  Tools({required this.factories, required this.colors}) {
+    _initIconsFromShapes();
+
+    if (factories.isNotEmpty) {
+      activeFactory.value = factories.first;
+    }
+
+    if (colors.isNotEmpty) {
+      activeColor.value = colors.first;
+    }
+  }
+
+  final _iconsInitCompleter = Completer<bool>();
+
+  void _initIconsFromShapes() async {
+    await Future.wait([
+      for (final factory in factories)
+        (factory as IconBoxMixin).updateIcon(activeColor.value),
+    ]);
+    _iconsInitCompleter.complete(Future.value(true));
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/factories/circle_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/factories/circle_factory.dart
@@ -5,7 +5,7 @@ import '../pattern/tool_factory.dart';
 import '../shapes/circle_shape.dart';
 import '../pattern/shape.dart';
 
-class CircleFactory extends FactoryTool with IconBoxMixin {
+class CircleFactory extends ToolFactory with IconBoxMixin {
   @override
   Shape createShape(double x, double y, Color color) {
     return CircleShape(

--- a/patterns/abstract_factory/tool_panel_factory/factories/circle_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/factories/circle_factory.dart
@@ -1,0 +1,18 @@
+import 'dart:ui';
+
+import '../mixin/icon_box_mixin.dart';
+import '../pattern/tool_factory.dart';
+import '../shapes/circle_shape.dart';
+import '../pattern/shape.dart';
+
+class CircleFactory extends FactoryTool with IconBoxMixin {
+  @override
+  Shape createShape(double x, double y, Color color) {
+    return CircleShape(
+      radius: 50,
+      x: x,
+      y: y,
+      color: color,
+    );
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/factories/line_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/factories/line_factory.dart
@@ -1,0 +1,18 @@
+import 'dart:ui';
+
+import '../mixin/icon_box_mixin.dart';
+import '../pattern/tool_factory.dart';
+import '../pattern/shape.dart';
+import '../shapes/line_shape.dart';
+
+class LineFactory extends FactoryTool with IconBoxMixin {
+  @override
+  Shape createShape(double x, double y, Color color) {
+    return LineShape(
+      length: 100,
+      x: x,
+      y: y,
+      color: color,
+    );
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/factories/line_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/factories/line_factory.dart
@@ -5,7 +5,7 @@ import '../pattern/tool_factory.dart';
 import '../pattern/shape.dart';
 import '../shapes/line_shape.dart';
 
-class LineFactory extends FactoryTool with IconBoxMixin {
+class LineFactory extends ToolFactory with IconBoxMixin {
   @override
   Shape createShape(double x, double y, Color color) {
     return LineShape(

--- a/patterns/abstract_factory/tool_panel_factory/factories/star_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/factories/star_factory.dart
@@ -1,0 +1,18 @@
+import 'dart:ui';
+
+import '../mixin/icon_box_mixin.dart';
+import '../pattern/tool_factory.dart';
+import '../pattern/shape.dart';
+import '../shapes/star_shape.dart';
+
+class StarFactory extends FactoryTool with IconBoxMixin {
+  @override
+  Shape createShape(double x, double y, Color color) {
+    return StarShape(
+      radius: 80,
+      x: x,
+      y: y,
+      color: color,
+    );
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/factories/star_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/factories/star_factory.dart
@@ -5,7 +5,7 @@ import '../pattern/tool_factory.dart';
 import '../pattern/shape.dart';
 import '../shapes/star_shape.dart';
 
-class StarFactory extends FactoryTool with IconBoxMixin {
+class StarFactory extends ToolFactory with IconBoxMixin {
   @override
   Shape createShape(double x, double y, Color color) {
     return StarShape(

--- a/patterns/abstract_factory/tool_panel_factory/factories/triangle_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/factories/triangle_factory.dart
@@ -1,0 +1,18 @@
+import 'dart:ui';
+
+import '../mixin/icon_box_mixin.dart';
+import '../pattern/tool_factory.dart';
+import '../pattern/shape.dart';
+import '../shapes/triangle_shape.dart';
+
+class TriangleFactory extends FactoryTool with IconBoxMixin {
+  @override
+  Shape createShape(double x, double y, Color color) {
+    return TriangleShape(
+      sideLength: 120,
+      x: x,
+      y: y,
+      color: color,
+    );
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/factories/triangle_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/factories/triangle_factory.dart
@@ -5,7 +5,7 @@ import '../pattern/tool_factory.dart';
 import '../pattern/shape.dart';
 import '../shapes/triangle_shape.dart';
 
-class TriangleFactory extends FactoryTool with IconBoxMixin {
+class TriangleFactory extends ToolFactory with IconBoxMixin {
   @override
   Shape createShape(double x, double y, Color color) {
     return TriangleShape(

--- a/patterns/abstract_factory/tool_panel_factory/factories/txt_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/factories/txt_factory.dart
@@ -5,12 +5,12 @@ import '../pattern/tool_factory.dart';
 import '../shapes/txt_shape.dart';
 import '../pattern/shape.dart';
 
-class TxtFactory extends FactoryTool with IconBoxMixin {
+class TxtFactory extends ToolFactory with IconBoxMixin {
   @override
   Shape createShape(double x, double y, Color color) {
     return Txt(
       text: 'Text',
-      fontSize: 100,
+      fontSize: 50,
       x: x,
       y: y,
       color: color,

--- a/patterns/abstract_factory/tool_panel_factory/factories/txt_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/factories/txt_factory.dart
@@ -1,0 +1,19 @@
+import 'dart:ui';
+
+import '../mixin/icon_box_mixin.dart';
+import '../pattern/tool_factory.dart';
+import '../shapes/txt_shape.dart';
+import '../pattern/shape.dart';
+
+class TxtFactory extends FactoryTool with IconBoxMixin {
+  @override
+  Shape createShape(double x, double y, Color color) {
+    return Txt(
+      text: 'Text',
+      fontSize: 100,
+      x: x,
+      y: y,
+      color: color,
+    );
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/main.dart
+++ b/patterns/abstract_factory/tool_panel_factory/main.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import 'app/app.dart';
+import 'app/shapes.dart';
+import 'app/tools.dart';
+import 'factories/circle_factory.dart';
+import 'factories/line_factory.dart';
+import 'factories/star_factory.dart';
+import 'factories/triangle_factory.dart';
+import 'factories/txt_factory.dart';
+import 'widgets/drawing_board.dart';
+import 'widgets/tool_panel.dart';
+
+class WToolPanelApp extends StatefulWidget {
+  const WToolPanelApp({Key? key}) : super(key: key);
+
+  @override
+  _WToolPanelAppState createState() => _WToolPanelAppState();
+}
+
+class _WToolPanelAppState extends State<WToolPanelApp> {
+  final app = App(
+    shapes: Shapes([]),
+    tools: Tools(
+      factories: [
+        TxtFactory(),
+        LineFactory(),
+        CircleFactory(),
+        TriangleFactory(),
+        StarFactory(),
+      ],
+      colors: [
+        Colors.white,
+        Colors.green,
+        Colors.blue,
+        Colors.yellow,
+      ],
+    ),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        DrawingBoard(
+          shapes: app.shapes,
+          onClick: app.addShape,
+        ),
+        ToolPanel(
+          tools: app.tools,
+        ),
+      ],
+    );
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/main.dart
+++ b/patterns/abstract_factory/tool_panel_factory/main.dart
@@ -11,14 +11,14 @@ import 'factories/txt_factory.dart';
 import 'widgets/drawing_board.dart';
 import 'widgets/tool_panel.dart';
 
-class WToolPanelApp extends StatefulWidget {
-  const WToolPanelApp({Key? key}) : super(key: key);
+class ToolPanelFactoryApp extends StatefulWidget {
+  const ToolPanelFactoryApp({Key? key}) : super(key: key);
 
   @override
-  _WToolPanelAppState createState() => _WToolPanelAppState();
+  _ToolPanelFactoryAppState createState() => _ToolPanelFactoryAppState();
 }
 
-class _WToolPanelAppState extends State<WToolPanelApp> {
+class _ToolPanelFactoryAppState extends State<ToolPanelFactoryApp> {
   final app = App(
     shapes: Shapes([]),
     tools: Tools(

--- a/patterns/abstract_factory/tool_panel_factory/mixin/icon_box_mixin.dart
+++ b/patterns/abstract_factory/tool_panel_factory/mixin/icon_box_mixin.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import '../pattern/tool_factory.dart';
 import '../pattern/shape.dart';
 
-mixin IconBoxMixin implements FactoryTool {
+mixin IconBoxMixin implements ToolFactory {
   Image? _icon;
 
   @override

--- a/patterns/abstract_factory/tool_panel_factory/mixin/icon_box_mixin.dart
+++ b/patterns/abstract_factory/tool_panel_factory/mixin/icon_box_mixin.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import '../pattern/tool_factory.dart';
+import '../pattern/shape.dart';
+
+mixin IconBoxMixin implements FactoryTool {
+  Image? _icon;
+
+  @override
+  Image get icon => _icon!;
+
+  Future<void> updateIcon(Color color) async {
+    final shape = createShape(0, 0, color);
+    final pngBytes = await _pngImageFromShape(shape);
+    _icon = Image.memory(
+      pngBytes,
+      fit: BoxFit.none,
+    );
+  }
+
+  Future<Uint8List> _pngImageFromShape(Shape shape) async {
+    final iconSize = 32.0;
+
+    final rec = PictureRecorder();
+    final can = Canvas(
+      rec,
+      Rect.fromLTWH(0, 0, iconSize, iconSize),
+    );
+
+    _scaleTo(can, shape, iconSize);
+    shape.paint(can);
+
+    final image = await rec.endRecording().toImage(
+          iconSize.toInt(),
+          iconSize.toInt(),
+        );
+    final bytes = await image.toByteData(format: ImageByteFormat.png);
+
+    if (bytes == null) {
+      throw 'Bytes is empty.';
+    }
+
+    return bytes.buffer.asUint8List();
+  }
+
+  void _scaleTo(Canvas can, Shape shape, double iconSize) {
+    var xMove = 0.0;
+    var yMove = 0.0;
+    late double w;
+    late double h;
+
+    if (shape.width >= shape.height) {
+      yMove = (shape.width - shape.height);
+      w = iconSize / shape.width;
+      h = iconSize / (shape.height + yMove);
+      yMove /= 2;
+    } else {
+      xMove = (shape.height - shape.width);
+      w = iconSize / (shape.width + xMove);
+      h = iconSize / shape.height;
+      xMove /= 2;
+    }
+
+    can.scale(w, h);
+    can.translate(xMove, yMove);
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/pattern/shape.dart
+++ b/patterns/abstract_factory/tool_panel_factory/pattern/shape.dart
@@ -1,0 +1,30 @@
+import 'dart:ui';
+
+abstract class Shape {
+  double get x => _x;
+
+  double get y => _y;
+
+  final Color color;
+
+  Shape({
+    required double x,
+    required double y,
+    required this.color,
+  })  : _x = x,
+        _y = y;
+
+  void paint(Canvas can);
+
+  double get width;
+
+  double get height;
+
+  void centerToFit() {
+    _x -= width / 2;
+    _y -= height / 2;
+  }
+
+  double _x;
+  double _y;
+}

--- a/patterns/abstract_factory/tool_panel_factory/pattern/tool_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/pattern/tool_factory.dart
@@ -2,7 +2,7 @@ import 'package:flutter/widgets.dart';
 
 import 'shape.dart';
 
-abstract class FactoryTool {
+abstract class ToolFactory {
   Shape createShape(double x, double y, Color color);
 
   Image get icon;

--- a/patterns/abstract_factory/tool_panel_factory/pattern/tool_factory.dart
+++ b/patterns/abstract_factory/tool_panel_factory/pattern/tool_factory.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/widgets.dart';
+
+import 'shape.dart';
+
+abstract class FactoryTool {
+  Shape createShape(double x, double y, Color color);
+
+  Image get icon;
+}

--- a/patterns/abstract_factory/tool_panel_factory/shapes/circle_shape.dart
+++ b/patterns/abstract_factory/tool_panel_factory/shapes/circle_shape.dart
@@ -1,0 +1,36 @@
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+
+import '../pattern/shape.dart';
+
+class CircleShape extends Shape {
+  final double radius;
+
+  CircleShape({
+    required this.radius,
+    required double x,
+    required double y,
+    required Color color,
+  }) : super(
+          x: x,
+          y: y,
+          color: color,
+        );
+
+  @override
+  void paint(Canvas can) {
+    final pos = width / 2;
+    can.drawCircle(
+      Offset(pos, pos),
+      radius,
+      Paint()..color = color,
+    );
+  }
+
+  @override
+  double get width => radius * 2;
+
+  @override
+  double get height => width;
+}

--- a/patterns/abstract_factory/tool_panel_factory/shapes/line_shape.dart
+++ b/patterns/abstract_factory/tool_panel_factory/shapes/line_shape.dart
@@ -1,0 +1,37 @@
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+
+import '../pattern/shape.dart';
+
+class LineShape extends Shape {
+  final double length;
+
+  LineShape({
+    required this.length,
+    required double x,
+    required double y,
+    required Color color,
+  }) : super(
+          x: x,
+          y: y,
+          color: color,
+        );
+
+  @override
+  void paint(Canvas can) {
+    can.drawLine(
+      Offset(0, length),
+      Offset(length, 0),
+      Paint()
+        ..color = color
+        ..strokeWidth = 3,
+    );
+  }
+
+  @override
+  double get width => length;
+
+  @override
+  double get height => length;
+}

--- a/patterns/abstract_factory/tool_panel_factory/shapes/star_shape.dart
+++ b/patterns/abstract_factory/tool_panel_factory/shapes/star_shape.dart
@@ -1,0 +1,52 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import '../pattern/shape.dart';
+
+class StarShape extends Shape {
+  final double radius;
+
+  StarShape({
+    required this.radius,
+    required double x,
+    required double y,
+    required Color color,
+  }) : super(
+          x: x,
+          y: y,
+          color: color,
+        );
+
+  @override
+  void paint(Canvas can) {
+    final path = Path()..addPolygon(_createStar(), true);
+    can.drawPath(path, Paint()..color = color);
+  }
+
+  @override
+  double get width => radius * 2;
+
+  @override
+  double get height => radius * 2;
+
+  List<Offset> _createStar() {
+    const alpha = (2 * pi) / 10;
+
+    final starXY = radius;
+
+    final points = <Offset>[];
+
+    for (var i = 11; i != 0; i--) {
+      var r = radius * (i % 2 + 1) / 2;
+      var omega = alpha * i;
+      points.add(Offset(
+        (r * sin(omega)) + starXY,
+        (r * cos(omega)) + starXY,
+      ));
+    }
+
+    return points;
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/shapes/triangle_shape.dart
+++ b/patterns/abstract_factory/tool_panel_factory/shapes/triangle_shape.dart
@@ -1,0 +1,49 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+
+import '../pattern/shape.dart';
+
+class TriangleShape extends Shape {
+  final double sideLength;
+
+  TriangleShape({
+    required this.sideLength,
+    required double x,
+    required double y,
+    required Color color,
+  }) : super(
+          x: x,
+          y: y,
+          color: color,
+        );
+
+  @override
+  void paint(Canvas can) {
+    final path = Path()
+      ..addPolygon(
+        [
+          Offset(0, height),
+          Offset(width / 2, 0),
+          Offset(width, height),
+        ],
+        true,
+      );
+
+    can.drawPath(
+      path,
+      Paint()
+        ..strokeJoin = StrokeJoin.round
+        ..style = PaintingStyle.stroke
+        ..color = color
+        ..strokeWidth = 5,
+    );
+  }
+
+  @override
+  double get width => sideLength;
+
+  @override
+  double get height => sideLength * sqrt(3) / 2;
+}

--- a/patterns/abstract_factory/tool_panel_factory/shapes/txt_shape.dart
+++ b/patterns/abstract_factory/tool_panel_factory/shapes/txt_shape.dart
@@ -1,0 +1,51 @@
+import 'dart:ui';
+
+import '../pattern/shape.dart';
+
+class Txt extends Shape {
+  final String text;
+  final double fontSize;
+
+  Txt({
+    required this.text,
+    required this.fontSize,
+    required double x,
+    required double y,
+    required Color color,
+  }) : super(
+          x: x,
+          y: y,
+          color: color,
+        ) {
+    _initTextParagraph();
+  }
+
+  @override
+  void paint(Canvas can) {
+    can.drawParagraph(_paragraph, Offset.zero);
+  }
+
+  @override
+  double get width => _paragraph.maxIntrinsicWidth;
+
+  @override
+  double get height => _paragraph.height;
+
+  late final Paragraph _paragraph;
+
+  void _initTextParagraph() {
+    final style = ParagraphStyle(
+      textDirection: TextDirection.ltr,
+    );
+    final tStyle = TextStyle(
+      fontFamily: 'Arial',
+      color: color,
+      fontSize: fontSize,
+    );
+    _paragraph = (ParagraphBuilder(style)
+          ..pushStyle(tStyle)
+          ..addText(text))
+        .build();
+    _paragraph.layout(ParagraphConstraints(width: double.infinity));
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/widgets/colors_tool_bar.dart
+++ b/patterns/abstract_factory/tool_panel_factory/widgets/colors_tool_bar.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import '../app/tools.dart';
+import 'independent/tool_bar.dart';
+import 'independent/tool_button.dart';
+
+class ColorsToolBar extends StatelessWidget {
+  final Tools tools;
+
+  const ColorsToolBar({Key? key, required this.tools}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ToolBar(
+      title: 'colors',
+      child: ValueListenableBuilder(
+        valueListenable: tools.activeColor,
+        builder: (_, activeColor, __) {
+          return Column(
+            children: [
+              for (final color in tools.colors)
+                ToolButton(
+                  icon: Icon(Icons.circle, color: color),
+                  active: color == activeColor,
+                  onTap: () {
+                    tools.activeColor.value = color;
+                  },
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/widgets/drawing_board.dart
+++ b/patterns/abstract_factory/tool_panel_factory/widgets/drawing_board.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import '../app/shapes.dart';
+import 'independent/event_listenable_builder.dart';
+import 'shape_widget.dart';
+
+class DrawingBoard extends StatelessWidget {
+  final Shapes shapes;
+  final Function(double x, double y) onClick;
+
+  const DrawingBoard({
+    Key? key,
+    required this.shapes,
+    required this.onClick,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: (e) => addShape(e.localPosition),
+      child: Container(
+        color: Color(0xff1f1f1f),
+        child: EventListenableBuilder(
+          event: shapes.onAddShapeEvent,
+          builder: (_) {
+            return Stack(
+              children: [
+                for (final shape in shapes) ShapeWidget(shape: shape),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  void addShape(Offset position) {
+    onClick(position.dx, position.dy);
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/widgets/factories_tool_bar.dart
+++ b/patterns/abstract_factory/tool_panel_factory/widgets/factories_tool_bar.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../app/tools.dart';
+import 'independent/tool_bar.dart';
+import 'independent/tool_button.dart';
+
+class FactoriesToolBar extends StatelessWidget {
+  final Tools tools;
+
+  const FactoriesToolBar({Key? key, required this.tools}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ToolBar(
+      title: 'factories',
+      child: FutureBuilder(
+        future: tools.iconsReady,
+        builder: (_, snapshot) {
+          return snapshot.hasData
+              ? _buildToolButtons()
+              : Padding(
+                  padding: EdgeInsets.all(10),
+                  child: CircularProgressIndicator());
+        },
+      ),
+    );
+  }
+
+  Widget _buildToolButtons() {
+    return ValueListenableBuilder(
+      valueListenable: tools.activeFactory,
+      builder: (_, activeFactory, __) {
+        return Column(
+          children: [
+            for (final factory in tools.factories)
+              ToolButton(
+                icon: factory.icon,
+                active: factory == activeFactory,
+                onTap: () => tools.activeFactory.value = factory,
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/widgets/independent/event_listenable_builder.dart
+++ b/patterns/abstract_factory/tool_panel_factory/widgets/independent/event_listenable_builder.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+class EventListenableBuilder<T extends ChangeNotifier> extends StatefulWidget {
+  final T event;
+  final Widget Function(BuildContext context) builder;
+
+  const EventListenableBuilder({
+    Key? key,
+    required this.event,
+    required this.builder,
+  }) : super(key: key);
+
+  @override
+  _EventListenableBuilderState createState() =>
+      _EventListenableBuilderState(event);
+}
+
+class _EventListenableBuilderState<T extends ChangeNotifier>
+    extends State<EventListenableBuilder<T>> {
+  final T event;
+
+  _EventListenableBuilderState(this.event);
+
+  @override
+  void initState() {
+    event.addListener(_update);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    event.removeListener(_update);
+    super.dispose();
+  }
+
+  void _update() {
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(context);
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/widgets/independent/hove.dart
+++ b/patterns/abstract_factory/tool_panel_factory/widgets/independent/hove.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class Hover extends StatefulWidget {
+  final Function(double hoverForce) builder;
+
+  const Hover({Key? key, required this.builder}) : super(key: key);
+
+  @override
+  _HoverState createState() => _HoverState();
+}
+
+class _HoverState extends State<Hover> with SingleTickerProviderStateMixin {
+  late final AnimationController _animation;
+
+  @override
+  void initState() {
+    _animation = AnimationController(
+      duration: Duration(milliseconds: 200),
+      value: 0.0,
+      vsync: this,
+    )..addListener(
+        () {
+          setState(() {});
+        },
+      );
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _animation.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: (_) {
+        _animation.forward(from: _animation.value);
+      },
+      onExit: (_) {
+        _animation.reverse();
+      },
+      child: widget.builder(_animation.value),
+    );
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/widgets/independent/tool_bar.dart
+++ b/patterns/abstract_factory/tool_panel_factory/widgets/independent/tool_bar.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+class ToolBar extends StatelessWidget {
+  final String title;
+  final Widget child;
+
+  const ToolBar({
+    Key? key,
+    required this.title,
+    required this.child,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildNamedPanel(
+      title: title,
+      child: child,
+    );
+  }
+
+  Widget _buildNamedPanel({required String title, required Widget child}) {
+    return Container(
+      width: 64,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+          color: Color(0xFF3B3B3B),
+          borderRadius: BorderRadius.all(Radius.circular(3)),
+          boxShadow: [
+            BoxShadow(
+              color: Color(0x7C000000),
+              blurRadius: 6,
+              offset: Offset(2, 2),
+            ),
+          ]),
+      child: Column(
+        children: [
+          _buildTitle(title),
+          child,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTitle(String title) {
+    return Container(
+      height: 20,
+      color: Colors.white10,
+      width: double.infinity,
+      alignment: Alignment.center,
+      child: Text(
+        title,
+        style: TextStyle(
+          color: Colors.white70,
+          fontSize: 13,
+          fontFamily: 'Arial',
+          decoration: TextDecoration.none,
+          fontWeight: FontWeight.normal,
+        ),
+      ),
+    );
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/widgets/independent/tool_button.dart
+++ b/patterns/abstract_factory/tool_panel_factory/widgets/independent/tool_button.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import 'hove.dart';
+
+class ToolButton extends StatelessWidget {
+  final Function() onTap;
+  final bool active;
+  final Widget icon;
+
+  const ToolButton({
+    Key? key,
+    required this.onTap,
+    required this.active,
+    required this.icon,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Hover(
+        builder: (hoverForce) {
+          return Container(
+            width: 64,
+            height: 64,
+            color: color(hoverForce),
+            child: Padding(
+              padding: EdgeInsets.all(16),
+              child: icon,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Color color(double hoverForce) => active
+      ? Color.lerp(Colors.white10, Colors.white12, hoverForce)!
+      : Color.lerp(Colors.transparent, Colors.white10, hoverForce)!;
+}

--- a/patterns/abstract_factory/tool_panel_factory/widgets/shape_widget.dart
+++ b/patterns/abstract_factory/tool_panel_factory/widgets/shape_widget.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import '../pattern/shape.dart';
+
+class ShapeWidget extends StatelessWidget {
+  final Shape shape;
+
+  const ShapeWidget({
+    Key? key,
+    required this.shape,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: shape.x,
+      top: shape.y,
+      child: CustomPaint(
+        size: Size(shape.width, shape.height),
+        painter: PaintShape(shape),
+      ),
+    );
+  }
+}
+
+class PaintShape extends CustomPainter {
+  final Shape shape;
+
+  PaintShape(this.shape);
+
+  @override
+  void paint(Canvas canvas, Size _) {
+    shape.paint(canvas);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter _) {
+    return false;
+  }
+}

--- a/patterns/abstract_factory/tool_panel_factory/widgets/tool_panel.dart
+++ b/patterns/abstract_factory/tool_panel_factory/widgets/tool_panel.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+import '../app/tools.dart';
+import 'colors_tool_bar.dart';
+import 'factories_tool_bar.dart';
+
+class ToolPanel extends StatelessWidget {
+  final Tools tools;
+  const ToolPanel({Key? key, required this.tools}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: 12,
+      top: 12,
+      child: Column(
+        children: [
+          FactoriesToolBar(tools: tools),
+          SizedBox(height: 24),
+          ColorsToolBar(tools: tools),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: design_patterns_dart
 description: Dart examples for all classic GoF design patterns.
-version: 0.22.0
+version: 0.23.0
 homepage: https://refactoring.guru/design-patterns
 repository: https://github.com/RefactoringGuru/design-patterns-dart
 issue_tracker: https://github.com/RefactoringGuru/design-patterns-dart/issue


### PR DESCRIPTION
# Abstract Factory Pattern
Abstract Factory is a creational design pattern that lets you produce families of related objects 
without specifying their concrete classes.

Tutorial: [here](https://refactoring.guru/design-patterns/abstract-factory).

### Online demo:
Click on the picture to see the [demo](https://RefactoringGuru.github.io/design-patterns-dart/#/abstract_factory/tool_panel_factory).

[![image](https://user-images.githubusercontent.com/8049534/168668992-369a1bab-9f97-4333-a20e-ffd06bf91b54.png)](https://refactoringguru.github.io/design-patterns-dart/#/abstract_factory/tool_panel_factory)

### Diagram:
![image](https://user-images.githubusercontent.com/8049534/168672053-73ae1c9c-8fad-45ae-9247-429f7b5da565.png)

### Client code (using the "createShape" method):
```dart
final app = App(
  tools: Tools(
    factories: [
      TxtFactory(),
      LineFactory(),
      CircleFactory(),
      TriangleFactory(),
      StarFactory(),
    ],
  ),
);

class App {
  void addShape(double x, double y) {
    final newShape = activeFactory.createShape(x, y, activeColor);
    shapes.add(newShape);
  }
}

mixin IconBoxMixin implements FactoryTool {
  Image? _icon;

  @override
  Image get icon => _icon!;

  Future<void> updateIcon(Color color) async {
    final shape = createShape(0, 0, color);
    final pngBytes = await _pngImageFromShape(shape);
    _icon = Image.memory(pngBytes);
  }
}
```

